### PR TITLE
Bump from GHC 7.8.4 to GHC 8.2.2 and 8.4.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .cabal-sandbox
 cabal.sandbox.config
 dist
+
+# Haskell Tool Stack-related
+.stack-work

--- a/quadratic-irrational.cabal
+++ b/quadratic-irrational.cabal
@@ -70,11 +70,11 @@ library
                  , Numeric.QuadraticIrrational.CyclicList
                  , Numeric.QuadraticIrrational.Internal.Lens
   hs-source-dirs: src
-  build-depends: base >= 4.6 && < 4.8
-               , arithmoi == 0.4.*
-               , containers == 0.5.*
-               , mtl == 2.1.*
-               , transformers == 0.3.*
+  build-depends: base >= 4.6 && < 4.12
+               , arithmoi >= 0.4
+               , containers >= 0.5 && < 0.6
+               , mtl >= 2.1 && < 2.3
+               , transformers >= 0.3 && < 0.6
   default-language: Haskell2010
   ghc-options: -Wall -O2 -funbox-strict-fields
 
@@ -86,10 +86,10 @@ test-suite tasty-tests
   hs-source-dirs: tests
   build-depends: base
                , quadratic-irrational
-               , numbers == 3000.*
+               , numbers >= 3000.0 && < 3000.3
                , QuickCheck >= 2.7 && < 3
-               , tasty == 0.8.*
-               , tasty-quickcheck == 0.8.*
+               , tasty >= 0.8 && < 1.2
+               , tasty-quickcheck >= 0.8 && < 0.11
   default-language: Haskell2010
   ghc-options: -Wall -O2 -funbox-strict-fields
 

--- a/src/Numeric/QuadraticIrrational.hs
+++ b/src/Numeric/QuadraticIrrational.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE CPP              #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ViewPatterns     #-}
 
 -- |
 -- Module      : Numeric.QuadraticIrrational
@@ -7,7 +9,7 @@
 -- License     : MIT
 -- Maintainer  : Johan Kiviniemi <devel@johan.kiviniemi.name>
 -- Stability   : provisional
--- Portability : ViewPatterns
+-- Portability : FlexibleContexts, ViewPatterns
 --
 -- A library for exact computation with
 -- <http://en.wikipedia.org/wiki/Quadratic_irrational quadratic irrationals>
@@ -68,16 +70,20 @@ module Numeric.QuadraticIrrational
   , module Numeric.QuadraticIrrational.CyclicList
   ) where
 
-import Control.Applicative
-import Control.Monad.State
-import qualified Data.Foldable as F
-import Data.List
-import Data.Maybe
-import Data.Ratio
-import qualified Data.Set as Set
-import Math.NumberTheory.Powers.Squares
-import Math.NumberTheory.Primes.Factorisation
-import Text.Read
+#if !MIN_VERSION_base(4,8,0)
+import Control.Applicative ((<$>), (<*>))
+import Data.Foldable (Foldable)
+#endif
+import Control.Monad.State (evalState, gets, modify)
+import Data.Foldable (toList)
+import Data.List (foldl')
+import Data.Maybe (fromMaybe)
+import Data.Ratio ((%), denominator, numerator)
+import qualified Data.Set as Set (empty, insert, member)
+import Math.NumberTheory.Powers.Squares (integerSquareRoot)
+import Math.NumberTheory.Primes.Factorisation (factorise)
+import Text.Read (Lexeme (Ident), Read (readListPrec, readPrec),
+  lexP, parens, prec, readListPrecDefault, step)
 
 import Numeric.QuadraticIrrational.CyclicList
 import Numeric.QuadraticIrrational.Internal.Lens
@@ -758,9 +764,9 @@ qiToContinuedFractionList num =
 --
 -- >>> [ continuedFractionApproximate n (1, repeat 1) | n <- [0,3..18] ]
 -- [1 % 1,5 % 3,21 % 13,89 % 55,377 % 233,1597 % 987,6765 % 4181]
-continuedFractionApproximate :: F.Foldable f
+continuedFractionApproximate :: Foldable f
                              => Int -> (Integer, f Integer) -> Rational
-continuedFractionApproximate n (i0, F.toList -> is) =
+continuedFractionApproximate n (i0, toList -> is) =
   fromInteger i0 +
     foldr (\(pos -> i) r -> recip (fromInteger i + r)) 0 (take n is)
   where

--- a/src/Numeric/QuadraticIrrational/CyclicList.hs
+++ b/src/Numeric/QuadraticIrrational/CyclicList.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 -- |
 -- Module      : Numeric.QuadraticIrrational.CyclicList
 -- Description : A container for a possibly cyclic list.
@@ -11,10 +13,17 @@ module Numeric.QuadraticIrrational.CyclicList
   ( CycList (..)
   ) where
 
-import Data.Foldable
-import Data.Monoid
+#if !MIN_VERSION_base(4,8,0)
+import Data.Foldable (foldMap)
+#endif
+#if !MIN_VERSION_base(4,9,0)
+import Data.Monoid ((<>))
+#endif
 
 -- | A container for a possibly cyclic list.
+--
+-- $setup
+-- >>> import Data.Foldable (toList)
 --
 -- >>> toList (NonCyc "hello")
 -- "hello"

--- a/src/Numeric/QuadraticIrrational/Internal/Lens.hs
+++ b/src/Numeric/QuadraticIrrational/Internal/Lens.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE RankNTypes #-}
 
 -- |
 -- Module      : Numeric.QuadraticIrrational.Internal.Lens
@@ -7,7 +7,7 @@
 -- License     : MIT
 -- Maintainer  : Johan Kiviniemi <devel@johan.kiviniemi.name>
 -- Stability   : provisional
--- Portability : Rank2Types
+-- Portability : RankNTypes
 --
 -- A tiny implementation of some lens primitives. Please see
 -- <http://hackage.haskell.org/package/lens> for proper documentation.
@@ -16,15 +16,14 @@ module Numeric.QuadraticIrrational.Internal.Lens
   ( Lens, Traversal, Lens', Traversal', Getting, Setting
   , view, over, set
   ) where
+import Control.Applicative (Const (Const), getConst)
+import Data.Functor.Identity (Identity (Identity), runIdentity)
 
-import Control.Applicative
-import Data.Functor.Identity
+type Lens      s t a b = forall f. Functor     f => (a -> f b) -> s -> f t
+type Traversal s t a b = forall f. Applicative f => (a -> f b) -> s -> f t
 
-type Lens      s t a b = Functor     f => (a -> f b) -> s -> f t
-type Traversal s t a b = Applicative f => (a -> f b) -> s -> f t
-
-type Lens'      s a = Functor     f => (a -> f a) -> s -> f s
-type Traversal' s a = Applicative f => (a -> f a) -> s -> f s
+type Lens'      s a = forall f. Functor     f => (a -> f a) -> s -> f s
+type Traversal' s a = forall f. Applicative f => (a -> f a) -> s -> f s
 
 type Getting r s a   = (a -> Const r a)  -> s -> Const r s
 type Setting s t a b = (a -> Identity b) -> s -> Identity t

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,3 @@
+resolver: nightly-2018-06-09
+packages:
+- .

--- a/tests/CyclicList.hs
+++ b/tests/CyclicList.hs
@@ -1,11 +1,15 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE CPP                  #-}
 
 module CyclicList (tests) where
 
-import Control.Applicative
-import qualified Data.Foldable as F
-import Test.Tasty
-import Test.Tasty.QuickCheck
+#if !MIN_VERSION_base(4,8,0)
+import Control.Applicative ((<$>), (<*>))
+#endif
+import Data.Foldable (toList)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (Arbitrary (arbitrary, shrink), Property, (===),
+  oneof, testProperty)
 
 import Numeric.QuadraticIrrational.CyclicList
 
@@ -25,16 +29,18 @@ tests =
     [ testProperty "fmap" . withListEquiv $ \asC asL ->
         initEq' (fmap (*10) asC) (fmap (*10) asL)
     , testProperty "toList" . withListEquiv $ \asC asL ->
-        take 1000 (F.toList asC) === take 1000 asL
+        take 1000 (toList asC) === take 1000 asL
     ]
 
 withListEquiv :: (CycList Integer -> [Integer] -> b) -> CycList Integer -> b
 withListEquiv f cl@(NonCyc as)   = f cl as
 withListEquiv f cl@(Cyc as b bs) = f cl (as ++ cycle (b:bs))
 
+{-
 initEq :: Eq a => CycList a -> [a] -> Bool
 initEq (NonCyc as)   cs = take 1000 cs == take 1000 as
 initEq (Cyc as b bs) cs = take 1000 cs == take 1000 (as ++ cycle (b:bs))
+-}
 
 initEq' :: (Eq a, Show a) => CycList a -> [a] -> Property
 initEq' (NonCyc as)   cs = take 1000 cs === take 1000 as

--- a/tests/QuadraticIrrational.hs
+++ b/tests/QuadraticIrrational.hs
@@ -1,13 +1,17 @@
-{-# LANGUAGE ViewPatterns #-}
-
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE CPP                  #-}
+{-# LANGUAGE ViewPatterns         #-}
 
 module QuadraticIrrational (tests) where
 
-import Control.Applicative
-import Data.Number.CReal
-import Test.Tasty
-import Test.Tasty.QuickCheck
+#if !MIN_VERSION_base(4,8,0)
+import Control.Applicative ((<$>), (<*>))
+#endif
+import Data.Number.CReal (CReal)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (Arbitrary (arbitrary, shrink),
+  NonNegative (NonNegative), NonZero (NonZero), Property, Testable, (===),
+  (==>), conjoin, counterexample, testProperty)
 
 import Numeric.QuadraticIrrational
 import Numeric.QuadraticIrrational.Internal.Lens

--- a/tests/doctests.hs
+++ b/tests/doctests.hs
@@ -1,14 +1,19 @@
+{-# LANGUAGE CPP        #-}
 {-# LANGUAGE MultiWayIf #-}
 
 module Main (main) where
 
-import Control.Applicative
-import Control.Monad
-import Control.Monad.List
-import Data.List
-import System.Directory
-import System.FilePath
-import Test.DocTest
+#if !MIN_VERSION_base(4,8,0)
+import Control.Applicative ((<$))
+#endif
+import Control.Applicative (empty)
+import Control.Monad (guard)
+import Control.Monad.List (ListT (ListT), liftIO,  runListT)
+import Data.List (isSuffixOf)
+import System.Directory (doesDirectoryExist, doesFileExist,
+  getDirectoryContents)
+import System.FilePath ((</>))
+import Test.DocTest (doctest)
 
 main :: IO ()
 main = do

--- a/tests/tasty.hs
+++ b/tests/tasty.hs
@@ -1,6 +1,6 @@
 module Main (main) where
 
-import Test.Tasty
+import Test.Tasty (TestTree, defaultMain, testGroup)
 
 import qualified CyclicList
 import qualified QuadraticIrrational


### PR DESCRIPTION
Also adds a `stack.yaml` file to help `stack` users and updates `.gitignore` accordingly.

Also adds explicit imports, to be express about what is imported from what module.

Certain things are now exported by the `Prelude` and do not need to be imported if the `base` package is sufficiently recent.

In module `Numeric.QuadraticIrrational.Internal.Lens`, `Rank2Types` is deprecated. Replaced by `RankNTypes`. Express `forall f.` is required since GHC 8.0.1.

In module `Numeric.QuadraticIrrational`, `FlexibleContexts` is required.

Dependencies are updated in `quadratic-irrational.cabal`.